### PR TITLE
Fixes for directory traversal and filenames with spaces

### DIFF
--- a/chromecastize.sh
+++ b/chromecastize.sh
@@ -204,11 +204,12 @@ for FILENAME in "$@"; do
   elif ! [ -e "$FILENAME" ]; then
     echo "File not found ($FILENAME). Skipping..."
   elif [ -d "$FILENAME" ]; then
-    for F in $(find "$FILENAME" -type f); do
-      process_file $F
+    find "$FILENAME" -type f -print0 | while read -d $'\0' F
+    do
+      process_file "$F"
     done
   elif [ -f "$FILENAME" ]; then
-    process_file $FILENAME
+    process_file "$FILENAME"
   else
     echo "Invalid file ($FILENAME). Skipping..."
   fi

--- a/chromecastize.sh
+++ b/chromecastize.sh
@@ -30,137 +30,137 @@ DEFAULT_GFORMAT=mkv
 # Usage: in_array "$needle" "${haystack[@]}"
 # See: http://fvue.nl/wiki/Bash:_Check_if_array_element_exists
 in_array() {
-    local hay needle=$1
-    shift
-    for hay; do
-        [[ $hay == $needle ]] && return 0
-    done
-    return 1
+  local hay needle=$1
+  shift
+  for hay; do
+    [[ $hay == $needle ]] && return 0
+  done
+  return 1
 }
 
 print_help() {
-	echo "Usage: chromecastize.sh [ --mp4 | --mkv ] <videofile1> [ videofile2 ... ]"
+  echo "Usage: chromecastize.sh [ --mp4 | --mkv ] <videofile1> [ videofile2 ... ]"
 }
 
 unknown_codec() {
-	echo "'$1' is an unknown codec. Please add it to the list in a CONFIG section."
+  echo "'$1' is an unknown codec. Please add it to the list in a CONFIG section."
 }
 
 is_supported_gformat() {
-	if in_array "$1" "${SUPPORTED_GFORMATS[@]}"; then
-                return 0
-        elif in_array "$1" "${UNSUPPORTED_GFORMATS[@]}"; then
-                return 1
-        else
-                unknown_codec "$1"
-                exit 1
-        fi
+  if in_array "$1" "${SUPPORTED_GFORMATS[@]}"; then
+    return 0
+  elif in_array "$1" "${UNSUPPORTED_GFORMATS[@]}"; then
+    return 1
+  else
+    unknown_codec "$1"
+    exit 1
+  fi
 }
 
 is_supported_vcodec() {
-	if in_array "$1" "${SUPPORTED_VCODECS[@]}"; then
-		return 0
-	elif in_array "$1" "${UNSUPPORTED_VCODECS[@]}"; then
-		return 1
-	else
-		unknown_codec "$1"
-		exit 1
-	fi
+  if in_array "$1" "${SUPPORTED_VCODECS[@]}"; then
+    return 0
+  elif in_array "$1" "${UNSUPPORTED_VCODECS[@]}"; then
+    return 1
+  else
+    unknown_codec "$1"
+    exit 1
+  fi
 }
 
 is_supported_acodec() {
-	if in_array "$1" "${SUPPORTED_ACODECS[@]}"; then
-		return 0
-	elif in_array "$1" "${UNSUPPORTED_ACODECS[@]}"; then
-		return 1
-	else
-		unknown_codec "$1"
-		exit 1
-	fi
+  if in_array "$1" "${SUPPORTED_ACODECS[@]}"; then
+    return 0
+  elif in_array "$1" "${UNSUPPORTED_ACODECS[@]}"; then
+    return 1
+  else
+    unknown_codec "$1"
+    exit 1
+  fi
 }
 
 is_supported_ext() {
-	EXT=`echo $1 | tr '[:upper:]' '[:lower:]'`
-	in_array "$EXT" "${SUPPORTED_EXTENSIONS[@]}"
+  EXT=`echo $1 | tr '[:upper:]' '[:lower:]'`
+  in_array "$EXT" "${SUPPORTED_EXTENSIONS[@]}"
 }
 
 mark_as_good() {
-	# add file as successfully converted
-	echo `$REALPATH "$1"` >> $HOME/processed_files
+  # add file as successfully converted
+  echo `$REALPATH "$1"` >> $HOME/processed_files
 }
 
 on_success() {
-	echo ""
-	FILENAME="$1"
-	BASENAME=`basename "$FILENAME"`
-	echo "- conversion succeeded; file '$FILENAME.$OUTPUT_GFORMAT' saved"
-	mark_as_good "$FILENAME.$OUTPUT_GFORMAT"
-	echo "- renaming original file as '$FILENAME.bak'"
-	mv "$FILENAME" "$FILENAME.bak"
+  echo ""
+  FILENAME="$1"
+  BASENAME=`basename "$FILENAME"`
+  echo "- conversion succeeded; file '$FILENAME.$OUTPUT_GFORMAT' saved"
+  mark_as_good "$FILENAME.$OUTPUT_GFORMAT"
+  echo "- renaming original file as '$FILENAME.bak'"
+  mv "$FILENAME" "$FILENAME.bak"
 }
 
 on_failure() {
-	echo ""
-	FILENAME="$1"
-	echo "- failed to convert '$FILENAME' (or conversion has been interrupted)"
-	echo "- deleting partially converted file..."
-	rm "$FILENAME.mkv" &> /dev/null
+  echo ""
+  FILENAME="$1"
+  echo "- failed to convert '$FILENAME' (or conversion has been interrupted)"
+  echo "- deleting partially converted file..."
+  rm "$FILENAME.mkv" &> /dev/null
 }
 
 process_file() {
-	echo "==========="
-        echo "Processing: $FILENAME"
+  echo "==========="
+  echo "Processing: $FILENAME"
 
-        # test extension
-        BASENAME=$(basename "$FILENAME")
-        EXTENSION="${BASENAME##*.}"
-        if ! is_supported_ext "$EXTENSION"; then
-                echo "- not a video format, skipping"
-                continue
-        fi
+  # test extension
+  BASENAME=$(basename "$FILENAME")
+  EXTENSION="${BASENAME##*.}"
+  if ! is_supported_ext "$EXTENSION"; then
+    echo "- not a video format, skipping"
+    continue
+  fi
 
-	# test if it's an `chromecastize` generated file
-	if grep -Fxq "`$REALPATH "$FILENAME"`" $HOME/processed_files; then
-		echo '- file was genereated by `chromecastize`, skipping'
-		continue
-	fi
+  # test if it's an `chromecastize` generated file
+  if grep -Fxq "`$REALPATH "$FILENAME"`" $HOME/processed_files; then
+    echo '- file was genereated by `chromecastize`, skipping'
+    continue
+  fi
 
-	# test general format
-        INPUT_GFORMAT=`mediainfo --Inform="General;%Format%\n" "$FILENAME" | head -n1`
-        if is_supported_gformat "$INPUT_GFORMAT" && [ "$OVERRIDE_GFORMAT" = "" ] || [ "$OVERRIDE_GFORMAT" = "$EXTENSION" ]; then
-                OUTPUT_GFORMAT="ok"
-        else
-                # if override format is specified, use it; otherwise fall back to default format
-                OUTPUT_GFORMAT="${OVERRIDE_GFORMAT:-$DEFAULT_GFORMAT}"
-        fi
-        echo "- general: $INPUT_GFORMAT -> $OUTPUT_GFORMAT"
+  # test general format
+  INPUT_GFORMAT=`mediainfo --Inform="General;%Format%\n" "$FILENAME" | head -n1`
+  if is_supported_gformat "$INPUT_GFORMAT" && [ "$OVERRIDE_GFORMAT" = "" ] || [ "$OVERRIDE_GFORMAT" = "$EXTENSION" ]; then
+    OUTPUT_GFORMAT="ok"
+  else
+    # if override format is specified, use it; otherwise fall back to default format
+    OUTPUT_GFORMAT="${OVERRIDE_GFORMAT:-$DEFAULT_GFORMAT}"
+  fi
+  echo "- general: $INPUT_GFORMAT -> $OUTPUT_GFORMAT"
 
-        # test video codec
-        INPUT_VCODEC=`mediainfo --Inform="Video;%Format%\n" "$FILENAME" | head -n1`
-        if is_supported_vcodec "$INPUT_VCODEC"; then
-                OUTPUT_VCODEC="copy"
-        else
-                OUTPUT_VCODEC="$DEFAULT_VCODEC"
-        fi
-        echo "- video: $INPUT_VCODEC -> $OUTPUT_VCODEC"
+  # test video codec
+  INPUT_VCODEC=`mediainfo --Inform="Video;%Format%\n" "$FILENAME" | head -n1`
+  if is_supported_vcodec "$INPUT_VCODEC"; then
+    OUTPUT_VCODEC="copy"
+  else
+    OUTPUT_VCODEC="$DEFAULT_VCODEC"
+  fi
+  echo "- video: $INPUT_VCODEC -> $OUTPUT_VCODEC"
 
-        # test audio codec
-        INPUT_ACODEC=`mediainfo --Inform="Audio;%Format%\n" "$FILENAME" | head -n1`
-        if is_supported_acodec "$INPUT_ACODEC"; then
-                OUTPUT_ACODEC="copy"
-        else
-                OUTPUT_ACODEC="$DEFAULT_ACODEC"
-        fi
-        echo "- audio: $INPUT_ACODEC -> $OUTPUT_ACODEC"
+  # test audio codec
+  INPUT_ACODEC=`mediainfo --Inform="Audio;%Format%\n" "$FILENAME" | head -n1`
+  if is_supported_acodec "$INPUT_ACODEC"; then
+    OUTPUT_ACODEC="copy"
+  else
+    OUTPUT_ACODEC="$DEFAULT_ACODEC"
+  fi
+  echo "- audio: $INPUT_ACODEC -> $OUTPUT_ACODEC"
 
-        if [ "$OUTPUT_VCODEC" = "copy" ] && [ "$OUTPUT_ACODEC" = "copy" ] && [ "$OUTPUT_GFORMAT" = "ok" ]; then
-                echo "- file should be playable by Chromecast!"
-		mark_as_good "$FILENAME"
-	else
-		echo "- video length: `mediainfo --Inform="General;%Duration/String3%" "$FILENAME"`"
-		$FFMPEG -loglevel error -stats -i "$FILENAME" -map 0 -scodec copy -vcodec "$OUTPUT_VCODEC" -acodec "$OUTPUT_ACODEC" "$FILENAME.$OUTPUT_GFORMAT" && on_success "$FILENAME" || on_failure "$FILENAME"
-		echo ""
-        fi
+  if [ "$OUTPUT_VCODEC" = "copy" ] && [ "$OUTPUT_ACODEC" = "copy" ] && [ "$OUTPUT_GFORMAT" = "ok" ]; then
+    echo "- file should be playable by Chromecast!"
+    mark_as_good "$FILENAME"
+  else
+    echo "- video length: `mediainfo --Inform="General;%Duration/String3%" "$FILENAME"`"
+    $FFMPEG -loglevel error -stats -i "$FILENAME" -map 0 -scodec copy -vcodec "$OUTPUT_VCODEC" -acodec "$OUTPUT_ACODEC" "$FILENAME.$OUTPUT_GFORMAT" && on_success "$FILENAME" || on_failure "$FILENAME"
+    echo ""
+  fi
 }
 
 ################
@@ -170,28 +170,28 @@ process_file() {
 # test if `mediainfo` is available
 MEDIAINFO=`which mediainfo`
 if [ -z $MEDIAINFO ]; then
-	echo '`mediainfo` is not available, please install it'
-	exit 1
+  echo '`mediainfo` is not available, please install it'
+  exit 1
 fi
 
 # test if `ffmpeg` is available
 FFMPEG=`which avconv || which ffmpeg`
 if [ -z $FFMPEG ]; then
-	echo '`avconv` (or `ffmpeg`) is not available, please install it'
-	exit 1
+  echo '`avconv` (or `ffmpeg`) is not available, please install it'
+  exit 1
 fi
 
 # test if `grealpath` or `realpath` is available
 REALPATH=`which realpath || which grealpath`
 if [ -z $REALPATH ]; then
-	echo '`grealpath` (or `realpath`) is not available, please install it'
-	exit 1
+  echo '`grealpath` (or `realpath`) is not available, please install it'
+  exit 1
 fi
 
 # check number of arguments
 if [ $# -lt 1 ]; then
-	print_help
-	exit 1
+  print_help
+  exit 1
 fi
 
 # ensure that processed_files file exists
@@ -199,17 +199,17 @@ mkdir -p $HOME
 touch $HOME/processed_files
 
 for FILENAME in "$@"; do
-	if [ "$FILENAME" = "--mp4" ] || [ "$FILENAME" = "--mkv" ]; then
-		OVERRIDE_GFORMAT=`echo "$FILENAME" | sed 's/^--//'`
-	elif ! [ -e "$FILENAME" ]; then
-		echo "File not found ($FILENAME). Skipping..."
-	elif [ -d "$FILENAME" ]; then
-		for F in $(find "$FILENAME" -type f); do
-			process_file $F
-		done
-	elif [ -f "$FILENAME" ]; then
-		process_file $FILENAME
-	else
-		echo "Invalid file ($FILENAME). Skipping..."
-	fi
+  if [ "$FILENAME" = "--mp4" ] || [ "$FILENAME" = "--mkv" ]; then
+    OVERRIDE_GFORMAT=`echo "$FILENAME" | sed 's/^--//'`
+  elif ! [ -e "$FILENAME" ]; then
+    echo "File not found ($FILENAME). Skipping..."
+  elif [ -d "$FILENAME" ]; then
+    for F in $(find "$FILENAME" -type f); do
+      process_file $F
+    done
+  elif [ -f "$FILENAME" ]; then
+    process_file $FILENAME
+  else
+    echo "Invalid file ($FILENAME). Skipping..."
+  fi
 done


### PR DESCRIPTION
Hi Petr,

Great script!  I made some local edits for the use case of converting all the content on my NAS.  The readme mentions the ability to use a directory as an input so I assume this regressed at some point.  I also had some files with spaces in the name, and your "for in" was delimiting filenames from "find" with spaces, so I changed it to delimit with \0 and parse it out.

I hope you don't find my whitespace change too aggressive, but I normally view content with tabs rendered as two spaces, and there were quite a few inconsistencies between using tabs vs spaces in the script, so I normalized them.  Feel free to ignore this change and fix-up the others to match whitespace.

-Elijah